### PR TITLE
Add required Debian packages for build (Close #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ it.
 * [requests](https://github.com/kennethreitz/requests) 2.10 or later
 * Hue bridge (tested with the first generation only)
 
+#### Requirements installation for Debian based distributions
+
+You will need following packages installed prior to running [installation (build)](https://github.com/craigcabrey/luminance#installing) on Debian Linux based distributions (Ubuntu, Elementary, Mint, Kali and etc ...)
+
+```
+sudo apt install autoconf autogen build-essential python-gi-dev libgtk-3-dev gsettings-desktop-schemas-dev libgnome-desktop-3-dev libxml2-utils && pip3 install phue
+```
+
 ### Installing
 
 1. Clone this repository.


### PR DESCRIPTION
Added packages which are required to be installed for installation (build) procedure to be successfully on Debian Linux based distributions. Closes: https://github.com/craigcabrey/luminance/issues/30