### PR TITLE
Include information on Debian requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ it.
 * [requests](https://github.com/kennethreitz/requests) 2.10 or later
 * Hue bridge (tested with the first generation only)
 
+Debian/Ubuntu cheat sheet:
+
+```
+sudo apt install autoconf python-gi-dev libgtk-3-dev python3-pip
+pip install --user phue netdisco requests
+```
+
 ### Installing
 
 1. Clone this repository.


### PR DESCRIPTION
It took me some time to find out how to get pygobject 3.0 on Debian. I figure it might be useful to have that shortcut there and maybe people from other distros can contribute theirs.